### PR TITLE
Initial Pixel Buds Pro 2 support

### DIFF
--- a/cli/src/bt.rs
+++ b/cli/src/bt.rs
@@ -9,6 +9,7 @@ use futures::StreamExt;
 
 
 const PIXEL_BUDS_CLASS: u32 = 0x240404;
+const PIXEL_BUDS2_CLASS: u32 = 0x244404;
 
 
 pub async fn find_maestro_device(adapter: &Adapter) -> Result<Device> {
@@ -16,7 +17,7 @@ pub async fn find_maestro_device(adapter: &Adapter) -> Result<Device> {
         let dev = adapter.device(addr)?;
 
         let class = dev.class().await?.unwrap_or(0);
-        if class != PIXEL_BUDS_CLASS {
+        if class != PIXEL_BUDS_CLASS && class != PIXEL_BUDS2_CLASS {
             continue;
         }
 


### PR DESCRIPTION
Adds the device class for the Buds Pro 2.

Tested most  of the status, seems to work, sample:
```
~/pbpctrl (budspro2) $ ./target/debug/pbpctrl show software
firmware:
  case:      release_2.117 (1726530399)
  left bud:  release_2.117 (1726530399)
  right bud: release_2.117 (1726530399)

~/pbpctrl (budspro2) $ ./target/debug/pbpctrl show hardware
serial numbers:
  case:      46221WRBEC2740
  left bud:  46171WRBDL0925
  right bud: 46191WRBDR1009

~/pbpctrl (budspro2) $ ./target/debug/pbpctrl show runtime
clock: 1728603498484 ms

battery:
  case:      unknown
  left bud:  100% (not charging)
  right bud: 100% (not charging)

placement:
  left bud:  out of case
  right bud: out of case

connection:
  local:  MaestroA
  remote: RightBtCore

~/pbpctrl (budspro2) $ ./target/debug/pbpctrl show battery
case:      unknown
left bud:  100% (not charging)
right bud: 100% (not charging)

~/pbpctrl (budspro2) $ ./target/debug/pbpctrl get multipoint
false

~/pbpctrl (budspro2) $ ./target/debug/pbpctrl get anc-gesture-loop
[active, aware]

~/pbpctrl (budspro2) $ ./target/debug/pbpctrl show runtime
clock: 1728603719450 ms

battery:
  case:      80% (not charging)
  left bud:  100% (not charging)
  right bud: 100% (charging)

placement:
  left bud:  out of case
  right bud: in case

connection:
  local:  MaestroA
  remote: LeftBtCore

```